### PR TITLE
PC-8368 - MessageDispatch not re-subscribing from correct position

### DIFF
--- a/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
+++ b/src/MessageDispatch.KurrentDB/KurrentDbSubscriber.cs
@@ -264,6 +264,7 @@ public class KurrentDbSubscriber
             catch (Exception ex)
             {
                 IsLive = false;
+                _startingPosition = _lastProcessedEventPosition;
                 _logger.LogError(ex, "Event Store subscription dropped {0}", SubscriptionDroppedReason.SubscriberError);
                 Console.WriteLine(ex);
             }


### PR DESCRIPTION
https://qphl.atlassian.net/browse/PC-8368

## What's Changed

- The _startingPosition is now set correctly when connection drops and subscription recreated